### PR TITLE
development/production-only routes

### DIFF
--- a/packages/polydev/src/middleware/router/handle.production.js
+++ b/packages/polydev/src/middleware/router/handle.production.js
@@ -5,6 +5,15 @@ module.exports = async function handle(router, file, routes) {
     routes.map(async ([httpMethod, route]) => {
       const method = httpMethod.toLowerCase()
       const exported = require(file)
+
+      if (!exported) {
+        return debug(
+          `Route %o does not have an exported handler from %o`,
+          route,
+          file.replace(process.cwd(), ".")
+        )
+      }
+
       const handler = await (exported.default || exported)
 
       debug(`router.${method}(%o, %o)`, route, file.replace(process.cwd(), "."))

--- a/packages/polydev/src/middleware/router/launcher.js
+++ b/packages/polydev/src/middleware/router/launcher.js
@@ -23,7 +23,7 @@ const routes = JSON.parse(routesString)
 async function startHandler() {
   const getLatestHandler = async () => {
     const exported = require(handlerPath)
-    const handler = await (exported.default || exported)
+    const handler = exported ? await (exported.default || exported) : exported
 
     return handler
   }
@@ -82,8 +82,10 @@ async function startHandler() {
       `${handlerPath.replace(
         process.cwd(),
         "."
-      )} does not return a Function or a Server`
+      )} does not return a Function, Server, or path to package.json`
     )
+    // In development, at least listen on PORT so that we can 404
+    express().listen(PORT)
   }
 
   process.on("message", bridge(PORT))

--- a/routes/dev-only/index.js
+++ b/routes/dev-only/index.js
@@ -1,0 +1,25 @@
+module.exports =
+  process.env.NODE_ENV === "development"
+    ? (req, res) => {
+        res.send(`
+          <head>
+            <link href="https://fonts.googleapis.com/css?family=Quicksand:300,500" rel="stylesheet">
+            <link href="/_polydev/styles.css" rel="stylesheet">
+          </head>
+
+          <body>
+            <div id="splash"></div>
+
+            <section>
+              <main>
+                <h1>🤫 Shhhh!</h1>
+
+                <p>
+                  This page is only available in <kbd>development</kbd>.
+                </p>
+              </main>
+            </section>
+          </body>
+        `)
+      }
+    : undefined

--- a/routes/index.js
+++ b/routes/index.js
@@ -26,6 +26,9 @@ module.exports = (req, res) => {
               <a href="/apollo-server">Apollo Server</a>
             </li>
             <li>
+              <a href="/dev-only">Development-Only Page</a>
+            </li>
+            <li>
               <a href="/express">Express</a>
             </li>
             <li>


### PR DESCRIPTION
```js
module.exports = process.env.NODE_ENV === "development" ? require('storybook-example') : undefined
```
