### PR TITLE
Support "-r" flags via child_process.fork/spawn?

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,8 @@ For customizing the `node` runtime, you can use `NODE_OPTIONS`.
 For example, [TypeScript][typescript] can be enabled via [ts-node][ts-node]:
 
 ```shell
+polydev --require ts-node/register
+# Or
 NODE_OPTIONS="--require ts-node/register" polydev
 ```
 

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "private": true,
   "scripts": {
     "postinstall": "yarn workspace polydev link",
-    "dev": "DEBUG=polydev polydev",
+    "dev": "DEBUG=polydev polydev -r ts-node/register",
     "dev:server": "DEBUG=polydev node server",
     "release": "cd packages/polydev && npx np --yolo",
     "prestart": "yarn workspace next-example build",

--- a/packages/polydev/README.md
+++ b/packages/polydev/README.md
@@ -47,6 +47,8 @@ For customizing the `node` runtime, you can use `NODE_OPTIONS`.
 For example, [TypeScript][typescript] can be enabled via [ts-node][ts-node]:
 
 ```shell
+polydev --require ts-node/register
+# Or
 NODE_OPTIONS="--require ts-node/register" polydev
 ```
 

--- a/packages/polydev/bin/polydev
+++ b/packages/polydev/bin/polydev
@@ -1,3 +1,15 @@
 #!/usr/bin/env node
 
-require("../src/server")
+const child_process = require("child_process")
+const path = require("path")
+
+const serverPath = path.resolve(__dirname, "../src/server.js")
+const [, , ...args] = process.argv
+
+// Remove polydev custom flags
+const execArgv = args.filter(arg => !["--open"].includes(arg))
+
+// Spawn server via node + flags
+child_process.fork(serverPath, args, {
+  execArgv
+})

--- a/packages/polydev/src/middleware/router/launcher.js
+++ b/packages/polydev/src/middleware/router/launcher.js
@@ -31,10 +31,12 @@ async function startHandler() {
   // Next.js returns a Promise for when the server is ready
   let handler = await getLatestHandler()
 
+  // @ts-ignore
   if (module.hot) {
     let recentlySaved = false
 
     if (typeof handler === "function") {
+      // @ts-ignore
       module.hot.accept(handlerPath, async () => {
         if (recentlySaved) {
           console.log(`♻️  Restarting ${handlerPath}`)


### PR DESCRIPTION
The first entry-point can spawn just like the sub-processes do.

This would allow `-r ts-node/register` to work more easily than `NODE_OPTIONS` IMO.