### PR TITLE
Errors in async routes don't throw/error

### DIFF
--- a/packages/polydev/package.json
+++ b/packages/polydev/package.json
@@ -1,6 +1,6 @@
 {
   "name": "polydev",
-  "version": "1.2.0",
+  "version": "1.3.0",
   "bin": "./bin/polydev",
   "main": "./src/index.js",
   "repository": "git@github.com:ericclemmons/polydev.git",

--- a/packages/polydev/src/middleware/router/handle.development.js
+++ b/packages/polydev/src/middleware/router/handle.development.js
@@ -106,7 +106,14 @@ module.exports = function handle(router, file, routes) {
       router,
       route,
       // Make sure we always evaluate at run-time for the latest HMR'd handler
-      (req, res) => handler(req, res)
+      (req, res, next) => {
+        const handled = handler(req, res, next)
+
+        // Automatically bubble up async errors
+        if (handled.catch) {
+          handled.catch(next)
+        }
+      }
     )
   })
 }

--- a/packages/polydev/src/middleware/router/handle.production.js
+++ b/packages/polydev/src/middleware/router/handle.production.js
@@ -22,7 +22,14 @@ module.exports = async function handle(router, file, routes) {
         router,
         route,
         // Make sure we always evaluate at run-time for the latest HMR'd handler
-        (req, res) => handler(req, res)
+        (req, res, next) => {
+          const handled = handler(req, res, next)
+
+          // Automatically bubble up async errors
+          if (handled.catch) {
+            handled.catch(next)
+          }
+        }
       )
     })
   )

--- a/packages/polydev/src/middleware/router/launcher.js
+++ b/packages/polydev/src/middleware/router/launcher.js
@@ -70,7 +70,14 @@ async function startHandler() {
         app,
         route,
         // Make sure we always evaluate at run-time for the latest HMR'd handler
-        (req, res) => handler(req, res)
+        (req, res, next) => {
+          const handled = handler(req, res, next)
+
+          // Automatically bubble up async errors
+          if (handled.catch) {
+            handled.catch(next)
+          }
+        }
       )
     })
 

--- a/routes/error/index.js
+++ b/routes/error/index.js
@@ -1,3 +1,3 @@
-module.exports = (req, res) => {
+module.exports = async (req, res) => {
   throw new Error("💥 Whoopsiedoodle! 🤷‍♂️ ")
 }


### PR DESCRIPTION
```js
module.exports = async (req, res) => {
  asdf
}
```

This error will never bubble up.