### PR TITLE
Parcel Example

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 .next
+*.log
 examples/**/*.lock
 dist
 node_modules

--- a/examples/500/package.json
+++ b/examples/500/package.json
@@ -1,6 +1,6 @@
 {
   "private": true,
-  "name": "404-example",
+  "name": "500-example",
   "version": "0.0.0",
   "scripts": {
     "dev": "polydev",

--- a/examples/parcel/.gitignore
+++ b/examples/parcel/.gitignore
@@ -1,0 +1,2 @@
+.cache
+public

--- a/examples/parcel/package.json
+++ b/examples/parcel/package.json
@@ -1,0 +1,16 @@
+{
+  "private": true,
+  "name": "parcel-example",
+  "version": "0.0.0",
+  "scripts": {
+    "dev": "polydev",
+    "start": "NODE_ENV=production polydev"
+  },
+  "devDependencies": {
+    "parcel-bundler": "^1.12.0"
+  },
+  "dependencies": {
+    "react": "^16.8.4",
+    "react-dom": "^16.8.4"
+  }
+}

--- a/examples/parcel/routes/index.js
+++ b/examples/parcel/routes/index.js
@@ -1,0 +1,4 @@
+const Bundler = require("parcel-bundler")
+const bundler = new Bundler("./src/index.html", { outDir: "./public" })
+
+module.exports = bundler.middleware()

--- a/examples/parcel/src/ParcelExample.js
+++ b/examples/parcel/src/ParcelExample.js
@@ -1,0 +1,36 @@
+import React, { Fragment, useState } from "react"
+
+export function ParcelExample() {
+  const [taps, setTaps] = useState(1)
+
+  return (
+    <Fragment>
+      <link
+        href="https://fonts.googleapis.com/css?family=Quicksand:300,500"
+        rel="stylesheet"
+      />
+      <link href="/_polydev/styles.css" rel="stylesheet" />
+
+      <div id="splash" />
+
+      <section>
+        <main>
+          <h1>
+            👋 Howdy from <kbd>Parcel</kbd>
+          </h1>
+
+          <p>
+            <kbd>{taps}</kbd> {taps ? "taps" : "tap"}
+          </p>
+          <p>
+            <button onClick={() => setTaps(taps + 1)}>Tap me again 👊</button>
+          </p>
+        </main>
+
+        <footer>
+          <a href="/">&laquo; Back</a>
+        </footer>
+      </section>
+    </Fragment>
+  )
+}

--- a/examples/parcel/src/index.html
+++ b/examples/parcel/src/index.html
@@ -1,0 +1,8 @@
+<html>
+
+<body>
+  <div id="root"></div>
+  <script src="./index.js"></script>
+</body>
+
+</html>

--- a/examples/parcel/src/index.js
+++ b/examples/parcel/src/index.js
@@ -1,0 +1,5 @@
+import React from "react"
+import { render } from "react-dom"
+import { ParcelExample } from "./ParcelExample"
+
+render(<ParcelExample />, document.getElementById("root"))

--- a/scripts/start.js
+++ b/scripts/start.js
@@ -1,17 +1,26 @@
 #!/usr/bin/env node
 
-const shell = require("shelljs")
+const { execSync } = require("child_process")
+const fs = require("fs")
+const path = require("path")
 
 const [, , example] = process.argv
-
-shell.cd("examples")
+const examplesDir = path.resolve(__dirname, "../examples")
 
 if (!example) {
-  const examples = shell.ls("-d", "*").map((file) => file)
+  const examples = fs
+    .readdirSync(examplesDir, "utf8")
+    .filter((folder) =>
+      fs.statSync(path.resolve(examplesDir, folder)).isDirectory()
+    )
 
   throw new Error(`$ yarn example ${examples}`)
 }
 
-shell.cd(example)
-shell.exec("yarn install --production")
-shell.exec("yarn start")
+const options = {
+  cwd: path.resolve(examplesDir, example),
+  stdio: "inherit"
+}
+
+execSync("yarn install", options)
+execSync("yarn start", options)


### PR DESCRIPTION
This works pretty easily via this:

```js
const Bundler = require("parcel-bundler");
const path = require("path");

const publicPath = path.resolve(__dirname, "../public");
const publicUrl = "./dist";

const bundler = new Bundler(path.resolve(publicPath, "index.html"), {
  outDir: path.resolve(publicPath, publicUrl),
  publicUrl
});

module.exports = bundler.middleware();
```

But I still want to enable `index.*.js` to support a `package.json`.