### PR TITLE
Jest can't resolve routes correctly

### DIFF
--- a/src/middleware/router/handle.production.js
+++ b/src/middleware/router/handle.production.js
@@ -1,5 +1,12 @@
 const debug = require("debug")("polydev")
 
+// ! Jest has a built-in mocking mechanism that can't correctly resolve project
+// ! files from node_modules:
+// @see https://github.com/facebook/jest/blob/72d01cc79f3dfe05419cd8dea1b6c9a558d93879/packages/jest-resolve/src/index.ts#L277-L279
+//
+// @ts-ignore
+if (require.requireActual) require = require.requireActual
+
 module.exports = async function handle(router, file, routes) {
   await Promise.all(
     routes.map(async ([httpMethod, route]) => {


### PR DESCRIPTION
This is incredibly hard to troubleshoot, but it goes something like this:

1. `project/node_modules/polydev/src/middleware/router/handle.production.js` attempts to `require("project/example/routes/login/index.ts")`
1. Jest does a bunch of resolution stuff, and ends up loading `project/index.js`.
1. Just incorrectly stores the module key as `user:project/node_modules/polydev/src/middleware/router/handle.production.js:`, because it can't resolve the absolute path or mock module location/meta.
